### PR TITLE
Added undo feature

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
 - [x] all-time leaderboard
 - [x] customizable leaderboard cutoff
 - [ ] user stats with overall place
-- [ ] undo last report feature
+- [x] undo last report feature
 - [ ] more precise time controls
 - [ ] get total games for a given time period
 

--- a/seeker.py
+++ b/seeker.py
@@ -17,6 +17,17 @@ async def on_ready():
     for guild in bot.guilds:
         print(guild)
 
+@bot.command(name='undo')
+async def undo(ctx):
+    user = ctx.author
+    results = undo_last_report(ctx.guild.id, user.id)
+    msg = ''
+    if results is None:
+        msg = 'Matches can only be undone within 5 minutes of the report.'
+    else:
+        msg = f'{user.mention}\'s most recent match deleted.'
+    await ctx.send(msg)
+
 @bot.command(name='report')
 async def report(ctx, user1: User, user1_games: int, user2: User, user2_games: int):
     if user1 not in bot.users:


### PR DESCRIPTION
Implemented an undo command for match reports. Undos can only be done within 5 minutes of a report, and only by one of the match participants. 